### PR TITLE
api call times handled, support for retry-after header, threadpool ad…

### DIFF
--- a/controller/interfaces/doc_recoverer.py
+++ b/controller/interfaces/doc_recoverer.py
@@ -26,12 +26,13 @@ class DocRecoverer(ABC):
         return "A document recoverer that retrieves documents based on a text query."
 
     @abstractmethod
-    def recover(self, query: str) -> Set[Document]:
+    def recover(self, query: str, k: int) -> Set[Document]:
         """
         Search logic to retrieve documents matching the given query.
 
         Args:
             query: A text query.
+            k: Number of documents to retrieve
 
         Returns:
             A set of Document instances matching the query.

--- a/doc_recoverers/pub_med_recoverer/pubMed_recoverer_impl.py
+++ b/doc_recoverers/pub_med_recoverer/pubMed_recoverer_impl.py
@@ -1,20 +1,27 @@
+import random
+import time
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from typing import Set, Dict, Any
 import requests
 from PyPDF2 import PdfReader
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from controller.interfaces.doc_recoverer import DocRecoverer
 from entities.document import Document
 from doc_recoverers.doc_utils.doc_cleaner import DocumentContentCleaner
 
 
 class PubMedRecoverer(DocRecoverer):
-    """Recover documents from PubMed with DOI PDF extraction and arXiv fallback."""
+    PUBMED_BACKOFF_MIN = 1.0
+    PUBMED_BACKOFF_MAX = 2.0
+    ARXIV_BACKOFF_MIN = 3.0
+    ARXIV_BACKOFF_MAX = 5.0
+    TIMEOUT = 15
+    MAX_RETRIES = 100
+    PDF_THREADS = 20
     ESEARCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
     EFETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
     ARXIV_API = "http://export.arxiv.org/api/query"
-    MAX_RESULTS = 10
-    TIMEOUT = 15
 
     @property
     def name(self) -> str:
@@ -24,58 +31,85 @@ class PubMedRecoverer(DocRecoverer):
     def description(self) -> str:
         return "Retrieves documents from PubMed using a text query, fetches metadata, attempts PDF via DOI negotiation, then falls back to arXiv by title."
 
-    def recover(self, query: str) -> Set[Document]:
+    def recover(self, query: str, k: int) -> Set[Document]:
         """Retrieve documents from PubMed based on a query.
 
         Args:
             query: Search query string
+            k: Number of documents to retrieve
 
         Returns:
             Set of recovered Document objects
         """
-        ids = self._search_pubmed(query)
+        ids = self._search_pubmed(query, k)
         documents = set()
+        doi_docs = set()
+        futures = []
 
+        metas = []
         for pmid in ids:
-            meta = self._fetch_metadata(pmid)
-            title = meta.get("title", "")
-            abstract = meta.get("abstract", "")
-            authors = meta.get("authors", [])
-            doi = meta.get("doi")
-            doc = None
+            metas.append((pmid, self._fetch_metadata(pmid)))
 
-            if doi:
-                doc = self._fetch_via_doi(
-                    doi,
-                    identifier=pmid,
-                    title=title,
-                    abstract=abstract,
-                    authors=authors
-                )
+        with ThreadPoolExecutor(max_workers=self.PDF_THREADS) as executor:
+            for pmid, meta in metas:
+                if meta.get("doi"):
+                    futures.append(executor.submit(
+                        self._fetch_via_doi,
+                        meta["doi"],
+                        identifier=pmid,
+                        title=meta["title"],
+                        abstract=meta["abstract"],
+                        authors=meta["authors"]
+                    ))
 
-            if not doc and title:
-                arxiv_docs = self._recover_from_arxiv(title)
-                if arxiv_docs:
-                    doc = next(iter(arxiv_docs))
+            for future in as_completed(futures):
+                doc = future.result()
+                if doc:
+                    doi_docs.add(doc)
 
-            if doc:
+        documents.update(doi_docs)
+        recovered_pmids = {doc.id for doc in doi_docs}
+
+        for pmid, meta in metas:
+            if pmid in recovered_pmids or not meta.get("title"):
+                continue
+            arxiv_docs = self._recover_from_arxiv(meta["title"])
+            if arxiv_docs:
+                doc = next(iter(arxiv_docs))
                 documents.add(doc)
 
         return documents
 
-    def _search_pubmed(self, query: str) -> list[str]:
+    def _search_pubmed(self, query: str, k: int) -> list[str]:
         """Search PubMed for document IDs matching the query.
 
         Args:
             query: Search query string
+            k: Number of documents to retrieve
 
         Returns:
             List of PubMed IDs
         """
-        params = {"db": "pubmed", "term": query, "retmax": self.MAX_RESULTS, "retmode": "json"}
-        resp = requests.get(self.ESEARCH_URL, params=params, timeout=self.TIMEOUT)
-        resp.raise_for_status()
-        return resp.json().get("esearchresult", {}).get("idlist", [])
+        params = {"db": "pubmed", "term": query, "retmax": k, "retmode": "json"}
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                resp = requests.get(self.ESEARCH_URL, params=params, timeout=self.TIMEOUT)
+                if resp.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(resp, self.PUBMED_BACKOFF_MIN, self.PUBMED_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                    continue
+                resp.raise_for_status()
+                return resp.json().get("esearchresult", {}).get("idlist", [])
+            except requests.HTTPError as e:
+                if e.response.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(e.response, self.PUBMED_BACKOFF_MIN, self.PUBMED_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                else:
+                    return []
+            except requests.RequestException:
+                time.sleep(random.uniform(self.PUBMED_BACKOFF_MIN, self.PUBMED_BACKOFF_MAX))
+        return []
 
     def _fetch_metadata(self, pmid: str) -> Dict[str, Any]:
         """Fetch metadata for a PubMed document.
@@ -87,29 +121,44 @@ class PubMedRecoverer(DocRecoverer):
             Dictionary containing title, abstract, authors, and DOI
         """
         params = {"db": "pubmed", "id": pmid, "retmode": "xml"}
-        resp = requests.get(self.EFETCH_URL, params=params, timeout=self.TIMEOUT)
-        resp.raise_for_status()
-        root = ET.fromstring(resp.content)
-        article = root.find(".//Article")
 
-        if article is None:
-            return {"title": "", "abstract": "", "authors": [], "doi": None}
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                resp = requests.get(self.EFETCH_URL, params=params, timeout=self.TIMEOUT)
+                if resp.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(resp, self.PUBMED_BACKOFF_MIN, self.PUBMED_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                    continue
+                resp.raise_for_status()
+                root = ET.fromstring(resp.content)
+                article = root.find(".//Article")
 
-        title = article.find("ArticleTitle").text or ""
-        abstract = " ".join(e.text or "" for e in article.findall(".//AbstractText")).strip()
-        authors = [
-            f"{a.findtext('ForeName', '')} {a.findtext('LastName', '')}".strip()
-            for a in article.findall(".//Author")
-        ]
+                if article is None:
+                    return {"title": "", "abstract": "", "authors": [], "doi": None}
 
-        # Fixed the DOI extraction
-        doi = None
-        for a in root.findall(".//ArticleId"):
-            if a.attrib.get("IdType") == "doi":
-                doi = a.text.strip()
-                break
+                title = article.find("ArticleTitle").text or ""
+                abstract = " ".join(e.text or "" for e in article.findall(".//AbstractText")).strip()
+                authors = [
+                    f"{a.findtext('ForeName', '')} {a.findtext('LastName', '')}".strip()
+                    for a in article.findall(".//Author")
+                ]
 
-        return {"title": title, "abstract": abstract, "authors": authors, "doi": doi}
+                doi = None
+                for a in root.findall(".//ArticleId"):
+                    if a.attrib.get("IdType") == "doi":
+                        doi = a.text.strip()
+                        break
+
+                return {"title": title, "abstract": abstract, "authors": authors, "doi": doi}
+            except requests.HTTPError as e:
+                if e.response.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(e.response, self.PUBMED_BACKOFF_MIN, self.PUBMED_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                else:
+                    return {"title": "", "abstract": "", "authors": [], "doi": None}
+            except requests.RequestException:
+                time.sleep(random.uniform(self.PUBMED_BACKOFF_MIN, self.PUBMED_BACKOFF_MAX))
+        return {"title": "", "abstract": "", "authors": [], "doi": None}
 
     def _fetch_via_doi(
             self, doi: str, *, identifier: str, title: str, abstract: str, authors: list[str]
@@ -165,13 +214,27 @@ class PubMedRecoverer(DocRecoverer):
         """
         search_q = f"id:{query.split('/')[-1]}" if (":" in query or "arxiv.org" in query) else f"all:{query}"
 
-        try:
-            resp = requests.get(
-                f"{self.ARXIV_API}?search_query={search_q}&start=0&max_results=1",
-                timeout=self.TIMEOUT
-            )
-            resp.raise_for_status()
-        except Exception:
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                resp = requests.get(
+                    f"{self.ARXIV_API}?search_query={search_q}&start=0&max_results=1",
+                    timeout=self.TIMEOUT
+                )
+                if resp.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(resp, self.ARXIV_BACKOFF_MIN, self.ARXIV_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                    continue
+                resp.raise_for_status()
+                break
+            except requests.HTTPError as e:
+                if e.response.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(e.response, self.ARXIV_BACKOFF_MIN, self.ARXIV_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                else:
+                    return set()
+            except requests.RequestException:
+                time.sleep(random.uniform(self.ARXIV_BACKOFF_MIN, self.ARXIV_BACKOFF_MAX))
+        else:
             return set()
 
         ns = {"atom": "http://www.w3.org/2005/Atom"}
@@ -209,3 +272,12 @@ class PubMedRecoverer(DocRecoverer):
             }
         except Exception:
             return set()
+
+    def _get_sleep_time(self, response, min_backoff, max_backoff) -> float:
+        retry_after = response.headers.get('Retry-After')
+        if retry_after:
+            try:
+                return float(retry_after) + random.uniform(0.1, 0.5)
+            except ValueError:
+                pass
+        return random.uniform(min_backoff, max_backoff)

--- a/doc_recoverers/semantic_scholar_recoverer/semantic_scholar_recoverer_impl.py
+++ b/doc_recoverers/semantic_scholar_recoverer/semantic_scholar_recoverer_impl.py
@@ -1,18 +1,25 @@
+import random
 import time
-from typing import Set
-import requests
 import xml.etree.ElementTree as ET
 from io import BytesIO
+from typing import Set
+import requests
 from PyPDF2 import PdfReader
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from controller.interfaces.doc_recoverer import DocRecoverer
 from entities.document import Document
 from doc_recoverers.doc_utils.doc_cleaner import DocumentContentCleaner
 
 
 class SemanticScholarRecoverer(DocRecoverer):
-    """Recover documents from Semantic Scholar with arXiv PDF fallback."""
-    BASE_URL = "https://api.semanticscholar.org/graph/v1/paper/search"
+    SEMANTIC_BACKOFF_MIN = 1.0
+    SEMANTIC_BACKOFF_MAX = 3.0
+    ARXIV_BACKOFF_MIN = 3.0
+    ARXIV_BACKOFF_MAX = 5.0
+    TIMEOUT = 15
     MAX_RETRIES = 100
+    PDF_THREADS = 20
+    BASE_URL = "https://api.semanticscholar.org/graph/v1/paper/search"
 
     @property
     def name(self) -> str:
@@ -22,54 +29,68 @@ class SemanticScholarRecoverer(DocRecoverer):
     def description(self) -> str:
         return "Retrieves documents from Semantic Scholar using a text query, with arXiv fallback."
 
-    def recover(self, query: str) -> Set[Document]:
+    def recover(self, query: str, k: int) -> Set[Document]:
         """Retrieve documents from Semantic Scholar based on a query.
 
         Args:
             query: Search query string
+            k: Number of documents to retrieve
 
         Returns:
             Set of recovered Document objects
         """
-        params = {"query": query, "fields": "title,abstract,authors,openAccessPdf", "limit": 10}
+        params = {"query": query, "fields": "title,abstract,authors,openAccessPdf", "limit": k}
         resp = None
 
         for attempt in range(self.MAX_RETRIES):
             try:
-                resp = requests.get(self.BASE_URL, params=params, timeout=10)
+                resp = requests.get(self.BASE_URL, params=params, timeout=self.TIMEOUT)
+                if resp.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(resp, self.SEMANTIC_BACKOFF_MIN, self.SEMANTIC_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                    continue
                 if resp.status_code == 200:
                     break
-                if resp.status_code in {403, 429}:
-                    time.sleep(0.5)
                 else:
-                    resp.raise_for_status()
+                    break
             except requests.RequestException:
-                if attempt == self.MAX_RETRIES - 1:
-                    raise
+                time.sleep(random.uniform(self.SEMANTIC_BACKOFF_MIN, self.SEMANTIC_BACKOFF_MAX))
 
         if not resp or resp.status_code != 200:
-            raise Exception(f"Failed Semantic Scholar query after {self.MAX_RETRIES} attempts: {resp.text}")
+            return set()
 
         papers = resp.json().get("data", [])
         documents = set()
+        futures = []
+
+        with ThreadPoolExecutor(max_workers=self.PDF_THREADS) as executor:
+            for paper in papers:
+                if paper.get("openAccessPdf", {}).get("url"):
+                    futures.append(executor.submit(
+                        self._fetch_and_clean,
+                        paper["openAccessPdf"]["url"],
+                        paper.get("paperId")
+                    ))
+
+            for future in as_completed(futures):
+                doc = future.result()
+                if doc:
+                    documents.add(doc)
+
+        recovered_ids = {doc.id for doc in documents}
 
         for paper in papers:
+            paper_id = paper.get("paperId")
+            if paper_id in recovered_ids or not paper.get("title"):
+                continue
+
             title = paper.get("title", "").strip()
             abstract = paper.get("abstract", "") or ""
             authors = [a.get("name", "") for a in paper.get("authors", [])]
-            pdf_info = paper.get("openAccessPdf") or {}
-            pdf_url = pdf_info.get("url")
-            doc = None
 
-            if pdf_url:
-                doc = self._fetch_and_clean(pdf_url, paper_id=paper.get("paperId"))
-
-            if not doc and title:
-                arxiv_docs = self._recover_from_arxiv(title)
-                if arxiv_docs:
-                    doc = next(iter(arxiv_docs))
-
-            if doc:
+            arxiv_docs = self._recover_from_arxiv(title)
+            if arxiv_docs:
+                doc = next(iter(arxiv_docs))
                 documents.add(
                     Document(
                         id=doc.id,
@@ -82,8 +103,7 @@ class SemanticScholarRecoverer(DocRecoverer):
 
         return documents
 
-    @staticmethod
-    def _fetch_and_clean(url: str, paper_id: str) -> Document | None:
+    def _fetch_and_clean(self, url: str, paper_id: str) -> Document | None:
         """Fetch PDF content from URL and clean it.
 
         Args:
@@ -94,7 +114,7 @@ class SemanticScholarRecoverer(DocRecoverer):
             Document object or None if processing fails
         """
         try:
-            r = requests.get(url, timeout=15)
+            r = requests.get(url, timeout=self.TIMEOUT)
             r.raise_for_status()
             reader = PdfReader(BytesIO(r.content))
             raw = "\n".join(page.extract_text() or "" for page in reader.pages)
@@ -107,8 +127,7 @@ class SemanticScholarRecoverer(DocRecoverer):
         except Exception:
             return None
 
-    @staticmethod
-    def _recover_from_arxiv(query: str) -> Set[Document]:
+    def _recover_from_arxiv(self, query: str) -> Set[Document]:
         """Fallback to arXiv when Semantic Scholar PDF is unavailable.
 
         Args:
@@ -123,11 +142,27 @@ class SemanticScholarRecoverer(DocRecoverer):
         else:
             search_q = f"all:{query}"
 
-        try:
-            resp = requests.get(f"http://export.arxiv.org/api/query?search_query={search_q}&start=0&max_results=1",
-                                timeout=10)
-            resp.raise_for_status()
-        except Exception:
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                resp = requests.get(
+                    f"http://export.arxiv.org/api/query?search_query={search_q}&start=0&max_results=1",
+                    timeout=self.TIMEOUT
+                )
+                if resp.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(resp, self.ARXIV_BACKOFF_MIN, self.ARXIV_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                    continue
+                resp.raise_for_status()
+                break
+            except requests.HTTPError as e:
+                if e.response.status_code in {429, 503, 301}:
+                    sleep_time = self._get_sleep_time(e.response, self.ARXIV_BACKOFF_MIN, self.ARXIV_BACKOFF_MAX)
+                    time.sleep(sleep_time)
+                else:
+                    return set()
+            except requests.RequestException:
+                time.sleep(random.uniform(self.ARXIV_BACKOFF_MIN, self.ARXIV_BACKOFF_MAX))
+        else:
             return set()
 
         ns = {"atom": "http://www.w3.org/2005/Atom"}
@@ -147,7 +182,7 @@ class SemanticScholarRecoverer(DocRecoverer):
         )
 
         try:
-            r = requests.get(pdf_url, timeout=15)
+            r = requests.get(pdf_url, timeout=self.TIMEOUT)
             r.raise_for_status()
             reader = PdfReader(BytesIO(r.content))
             raw = "\n".join(p.extract_text() or "" for p in reader.pages)
@@ -167,3 +202,12 @@ class SemanticScholarRecoverer(DocRecoverer):
             }
         except Exception:
             return set()
+
+    def _get_sleep_time(self, response, min_backoff, max_backoff) -> float:
+        retry_after = response.headers.get('Retry-After')
+        if retry_after:
+            try:
+                return float(retry_after) + random.uniform(0.1, 0.5)
+            except ValueError:
+                pass
+        return random.uniform(min_backoff, max_backoff)


### PR DESCRIPTION
This pull request introduces enhancements to the document recovery system across multiple recoverers (`arXiv`, `PubMed`, and `Semantic Scholar`). The changes improve scalability, introduce concurrency for PDF processing, and implement better error handling with adaptive backoff strategies. Additionally, the `recover` method now supports limiting the number of retrieved documents (`k` parameter).

### Concurrency and Scalability Improvements:
* Introduced `ThreadPoolExecutor` to parallelize PDF processing in `arXivRecoverer`, `PubMedRecoverer`, and `SemanticScholarRecoverer`, allowing up to 20 threads for concurrent downloads. (`[[1]](diffhunk://#diff-0852f4ce1fc0e515649fe52d490af287c2f7948e4d1e1b84cad5f64d5b7c569dL28-R110)`, `[[2]](diffhunk://#diff-c48ad27466afa49fbade5781b890e3f69bb25f8f5c21a1eeb3fbf70bc739ee52L27-R112)`, `[[3]](diffhunk://#diff-fe7406c3d070298cdba6abb692b0a415c91abe09cbacc2930aace58dd595ca0eL85-R106)`)

### Enhanced Error Handling:
* Added adaptive backoff logic for handling HTTP errors (e.g., 429, 503) in all recoverers, leveraging `Retry-After` headers when available or falling back to randomized delays. (`[[1]](diffhunk://#diff-0852f4ce1fc0e515649fe52d490af287c2f7948e4d1e1b84cad5f64d5b7c569dR143-R151)`, `[[2]](diffhunk://#diff-c48ad27466afa49fbade5781b890e3f69bb25f8f5c21a1eeb3fbf70bc739ee52R124-R131)`, `[[3]](diffhunk://#diff-fe7406c3d070298cdba6abb692b0a415c91abe09cbacc2930aace58dd595ca0eL25-L72)`)

### API Enhancements:
* Updated the `recover` method signature to include a `k` parameter, allowing users to specify the maximum number of documents to retrieve. This change is reflected in `arXivRecoverer`, `PubMedRecoverer`, and `SemanticScholarRecoverer`. (`[[1]](diffhunk://#diff-38e7bb9856261499940ad3b20ea2f7041dcc43e33143831c4eb4454737f7b3feL29-R35)`, `[[2]](diffhunk://#diff-0852f4ce1fc0e515649fe52d490af287c2f7948e4d1e1b84cad5f64d5b7c569dL28-R110)`, `[[3]](diffhunk://#diff-c48ad27466afa49fbade5781b890e3f69bb25f8f5c21a1eeb3fbf70bc739ee52L27-R112)`, `[[4]](diffhunk://#diff-fe7406c3d070298cdba6abb692b0a415c91abe09cbacc2930aace58dd595ca0eL25-L72)`)

### Code Refactoring:
* Extracted `_get_sleep_time` helper methods in `arXivRecoverer`, `PubMedRecoverer`, and `SemanticScholarRecoverer` to centralize backoff logic. (`[[1]](diffhunk://#diff-0852f4ce1fc0e515649fe52d490af287c2f7948e4d1e1b84cad5f64d5b7c569dR143-R151)`, `[[2]](diffhunk://#diff-c48ad27466afa49fbade5781b890e3f69bb25f8f5c21a1eeb3fbf70bc739ee52R275-R283)`, `[[3]](diffhunk://#diff-fe7406c3d070298cdba6abb692b0a415c91abe09cbacc2930aace58dd595ca0eL85-R106)`)
* Refactored metadata fetching in `PubMedRecoverer` to batch process metadata and avoid redundant API calls. (`[doc_recoverers/pub_med_recoverer/pubMed_recoverer_impl.pyL27-R112](diffhunk://#diff-c48ad27466afa49fbade5781b890e3f69bb25f8f5c21a1eeb3fbf70bc739ee52L27-R112)`)

### Other Changes:
* Increased `MAX_RETRIES` to 100 for better resilience during transient failures. (`[[1]](diffhunk://#diff-0852f4ce1fc0e515649fe52d490af287c2f7948e4d1e1b84cad5f64d5b7c569dL1-R20)`, `[[2]](diffhunk://#diff-c48ad27466afa49fbade5781b890e3f69bb25f8f5c21a1eeb3fbf70bc739ee52R1-L17)`, `[[3]](diffhunk://#diff-fe7406c3d070298cdba6abb692b0a415c91abe09cbacc2930aace58dd595ca0eR1-R22)`)